### PR TITLE
install_github dependency issue

### DIFF
--- a/R/github_install.R
+++ b/R/github_install.R
@@ -1,7 +1,7 @@
 github_install <- function(repo, username, ref = "master", args = NULL, upgrade_dependencies = FALSE, ...){
   #get args
   all_args <- list(...)
-  all_args$upgrade_dependencies <- upgrade_dependencies;
+  all_args$dependencies <- upgrade_dependencies;
   all_args$repo <- paste(username, repo, sep="/");
   all_args$ref <- ref;
 


### PR DESCRIPTION
Fixing the default option for installing dependencies.  Is there a way to specify this in the url?  Would that be a better fix?